### PR TITLE
Add options to open file in text editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ Generate a new moulinette using the generator:
 
 This will generate a new file in `lib/tasks/moulinettes` using the [template provided in the gem](lib/generators/moulinettes/yyyymmdd_action_of_a_moulinette_task.rake).
 
+### Options
+
+You can also pass the following options to the generator:
+
+- `--editor` or `-e` to specify the editor to be used to open the file. Default is `$EDITOR`.
+- `--open` or `-o` to flag the file to be opened in your default editor after generation. Default is `true`.
+
 You can then run the task using the following command:
 
 ```bash

--- a/lib/generators/moulinettes/moulinette_generator.rb
+++ b/lib/generators/moulinettes/moulinette_generator.rb
@@ -3,6 +3,9 @@ require "rails/generators"
 module Moulinettes
   module Generators
     class MoulinetteGenerator < Rails::Generators::NamedBase
+      class_option :editor, type: :string, default: $EDITOR, desc: "Open the generated file in the specified editor"
+      class_option :open, type: :boolean, default: true, desc: "Open the generated file in your editor"
+      
       desc "This generator creates a task file following the moulinettes template"
 
       source_root File.expand_path(File.dirname(__FILE__))
@@ -11,6 +14,10 @@ module Moulinettes
         copy_file "yyyymmdd_action_of_a_moulinette_task.rake", filepath
         gsub_file filepath, "action_of_a_moulinette_task", task_name
         gsub_file filepath, "A description of the task goes here", task_description
+
+        if options["open"]
+          system("#{options["editor"]} #{filepath}")
+        end
       end
 
       def timestamp


### PR DESCRIPTION
Adds 2 options:
  - `editor` (string) allows specifying an editor. Default: system editor.
  - `editor` (boolean) determines if file should be open or not on creation. Default: true.