### PR TITLE
Add 'subject' option to generator

### DIFF
--- a/lib/generators/moulinettes/moulinette_generator.rb
+++ b/lib/generators/moulinettes/moulinette_generator.rb
@@ -5,6 +5,7 @@ module Moulinettes
     class MoulinetteGenerator < Rails::Generators::NamedBase
       class_option :editor, type: :string, default: ENV["EDITOR"], desc: "Open the generated file in the specified editor"
       class_option :open, type: :boolean, default: true, desc: "Open the generated file in your editor"
+      class_option :subject, type: :string, default: nil, desc: "The model to use as a subject"
       
       desc "This generator creates a task file following the moulinettes template"
 
@@ -14,6 +15,11 @@ module Moulinettes
         copy_file "yyyymmdd_action_of_a_moulinette_task.rake", filepath
         gsub_file filepath, "action_of_a_moulinette_task", task_name
         gsub_file filepath, "A description of the task goes here", task_description
+
+        if options["subject"].present?
+          gsub_file filepath, "subject", options["subject"].underscore
+          gsub_file filepath, "YourModel", options["subject"].classify 
+        end
 
         print_warnings
 


### PR DESCRIPTION
Adds a `subject` option to the moulinette generator. If such an option is passed, its value is used to define the variables & model names used in the moulinette.